### PR TITLE
Dev merge: Quick fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # discord-kat
-## Version 3.0.0 branch
+## Version 3.0.0_dev branch
 
 
 

--- a/cogs/level.py
+++ b/cogs/level.py
@@ -92,8 +92,8 @@ class Level(KatCog.KatCog):
 
 
     # Used when we need to award XP from message length.
-    def xp_algorithm(self, msglen):
-        return min(max((msglen / 0.9) * 0.3, 10), 200)
+    def xp_algorithm(self, msglen, guild):
+        return min(max((msglen / 0.9) * 0.3, 10), 200) * guild.ensure_exists("settings.level.xp_multi", "1.0")
 
 
     # The function that adds xp to user and calculates new levels.

--- a/kat.py
+++ b/kat.py
@@ -229,7 +229,7 @@ class Kat(commands.Bot):
     def get_custom_prefix(self, bot, message):
         """Callable, returns the prefix for the message's guild."""
         prefix = self.sql.ensure_exists(
-            "KatGuild", guild_id=message.guild.id).prefix
+            "KatGuild", guild_id=message.guild.id).ensure_setting("settings.prefix",self.settings['default_prefix'])
         return commands.when_mentioned_or(*prefix)(bot, message)
 
     def load_settings(self):


### PR DESCRIPTION
Prefix setting location changed in DB from column prefix to settings blob. Code changes to adapt to this.
Level cog now actually uses the multiplier for guild settings. (turns out I never did implemented this before)